### PR TITLE
New sensor values can be received and stored upon changing.

### DIFF
--- a/src/katportal_server.py
+++ b/src/katportal_server.py
@@ -112,6 +112,7 @@ class BLKATPortalClient(object):
         """
         cam_url = self.redis_server.get("{}:{}".format(product_id, 'cam:url'))
         client = KATPortalClient(cam_url, on_update_callback=partial(self.on_update_callback_fn, product_id), logger=logger)
+        #client = KATPortalClient(cam_url, on_update_callback=lambda x: self.on_update_callback_fn(product_id), logger=logger)
         self.subarray_katportals[product_id] = client
         logger.info("Created katportalclient object for : {}".format(product_id))
         sensors_to_query = [] # TODO: add sensors to query on ?configure
@@ -135,7 +136,7 @@ class BLKATPortalClient(object):
         write_list_redis(self.redis_server, key, repr(schedule_blocks)) #overrides previous list
         # Start io_loop to listen to sensors whose values should be registered
         # immediately when they change.
-        self.io_loop.add_callback(self.subscribe_sensors(product_id))
+        self.io_loop.add_callback(lambda: self.subscribe_sensors(product_id))
         self.io_loop.start()
         # Once off sensor values
         sensors_to_query = [] # TODO:  add sensors to query on ?capture_init


### PR DESCRIPTION
Using websocket subscriptions, new sensor values can be updated and stored at the specific time that they change. The list of sensors for subscription can be specified separately to the once-off sensor queries which still occur upon each CAM request (such as `?configure`, `?capture-init`, etc). 

Currently, sensors are subscribed to on `?capture-init` (as some sensors only become available after subarray configuration has been completed) and unsubscribed from on `?capture-done`.

In the function `_get_future_targets`I have replaced `portal_client` (occurring once-off) with `client`; please check if this is desired. Also, would some of the lines in the function `_capture_stop` be vestigial in the sense that they're presently handled elsewhere in the code?