### PR TITLE
Move contents of requirements.txt to setup.py

### DIFF
--- a/meerkat_backend_interface/katportal_server.py
+++ b/meerkat_backend_interface/katportal_server.py
@@ -5,9 +5,13 @@ import uuid
 from katportalclient import KATPortalClient
 from katportalclient.client import SensorNotFoundError
 import redis
-from src.redis_tools import *
 from functools import partial
 
+from .redis_tools import (
+    REDIS_CHANNELS,
+    write_pair_redis,
+    write_list_redis,
+    )
 from .logger import log as logger
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,6 @@
-backports-abc==0.5
-backports.ssl-match-hostname==3.5.0.1
-certifi==2018.4.16
-chardet==3.0.4
-cmd2==0.8.7
-contextlib2==0.5.5
-docker==3.4.0
-docker-pycreds==0.3.0
-docopt==0.6.2
-enum34==1.1.6
-future==0.16.0
-futures==3.2.0
-idna==2.7
-ipaddress==1.0.22
-Jinja2>=2.10.1
-katcp==0.6.2
-lxml==4.2.3
-MarkupSafe==1.0
-omnijson==0.1.2
-pipreqs==0.4.9
-ply==3.11
-psutil==5.4.6
-pyparsing==2.2.0
-pyperclip==1.6.2
-redis==2.10.6
-requests>=2.20.0
-singledispatch==3.4.0.3
-six==1.11.0
-slacker==0.9.65
-subprocess32==3.5.2
-tornado==4.5.3
-ujson==1.35
-urllib3==1.23
-wcwidth==0.1.7
-weather-api==1.0.4
-websocket-client==0.48.0
-yarg==0.1.9
-katpoint
+# development requirements
+#flake8
+#pytest-cov
+
+# run-time requirements
+-e .

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,46 @@
 import setuptools
 
+requires = [
+    'backports-abc==0.5',
+    'backports.ssl-match-hostname==3.5.0.1',
+    'certifi==2018.4.16',
+    'chardet==3.0.4',
+    'cmd2==0.8.7',
+    'contextlib2==0.5.5',
+    'docker==3.4.0',
+    'docker-pycreds==0.3.0',
+    'docopt==0.6.2',
+    'enum34==1.1.6',
+    'future==0.16.0',
+    'futures==3.2.0',
+    'idna==2.7',
+    'ipaddress==1.0.22',
+    'Jinja2>=2.10.1',
+    'katcp==0.6.2',
+    'katpoint',
+    'lxml==4.2.3',
+    'MarkupSafe==1.0',
+    'omnijson==0.1.2',
+    'pipreqs==0.4.9',
+    'ply==3.11',
+    'psutil==5.4.6',
+    'pyparsing==2.2.0',
+    'pyperclip==1.6.2',
+    'redis==2.10.6',
+    'requests>=2.20.0',
+    'singledispatch==3.4.0.3',
+    'six==1.11.0',
+    'slacker==0.9.65',
+    'subprocess32==3.5.2',
+    'tornado==4.5.3',
+    'ujson==1.35',
+    'urllib3==1.23',
+    'wcwidth==0.1.7',
+    'weather-api==1.0.4',
+    'websocket-client==0.48.0',
+    'yarg==0.1.9',
+    ]
+
 setuptools.setup(
     name="meerkat-backend-interface",
     version="1.0.0",
@@ -19,7 +60,7 @@ setuptools.setup(
         ],
     packages=setuptools.find_packages(),
 
-    install_requires=[],
+    install_requires=requires,
 
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
I've added text to `requirements.txt` so that you can do

    pip install -r requirements.txt

and have it use the requirements in `setup.py`.  There are also commented packages that one can uncomment to start writing tests with.  For that one can do a development (aka editable) install and have testing available, when doing the pip install above.